### PR TITLE
Fix #1: Recursive submodules for other GHAs (docs, wokwi_test) to match gds GHA

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,6 +13,8 @@ jobs:
     # need the repo checked out
     - name: checkout repo
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     # tt tools
     - name: checkout tt tools repo

--- a/.github/workflows/wokwi_test.yaml
+++ b/.github/workflows/wokwi_test.yaml
@@ -9,6 +9,8 @@ jobs:
     # need the repo checked out
     - name: checkout repo
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     # install oss fpga tools
     - name: install oss-cad-suite


### PR DESCRIPTION
I just copied these lines from the `checkout repo` step in `gds.yaml`, and put them into `docs` and `wokwi_test` in order make all 3 consistent:
```yaml
      with:
        submodules: recursive
```
...and this means all 3 GHAs will now correctly support git submodules.