### PR TITLE
GDS to PNG rendering with text labels hidden and much better PNG compression

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,6 +13,8 @@ jobs:
     # need the repo checked out
     - name: checkout repo
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     # tt tools
     - name: checkout tt tools repo

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -17,6 +17,14 @@ jobs:
     # ubuntu
     runs-on: ubuntu-latest
     steps:
+
+    # install librsvg2-bin (for rsvg-convert) and pngquant (for heavy PNG compression)
+    - name: install prerequisites
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: librsvg2-bin pngquant
+        version: tt03p5 # I think naming a version builds a reusable packages cache for that name.
+
     # need the repo checked out
     - name: checkout repo
       uses: actions/checkout@v3
@@ -81,8 +89,16 @@ jobs:
         key: ${{ runner.os }}-runs-${{ github.run_id }}
 
     # create png
-    - name: png
-      run: ./tt/tt_tool.py --create-png
+    - name: render svg from gds
+      run: ./tt/tt_tool.py --create-svg
+
+    - name: convert svg to png
+      run: |
+        echo 'text { display:none; }' > gds_render.css
+        rsvg-convert gds_render.svg -s gds_render.css -o gds_render_png24.png --no-keep-image-data
+
+    - name: shrink png
+      run: pngquant --nofs --strip --output gds_render.png gds_render_png24.png
 
     - name: populate png cache
       uses: actions/cache@v3

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -93,12 +93,12 @@ jobs:
       run: ./tt/tt_tool.py --create-svg
 
     - name: convert svg to png
-      run: |
-        echo 'text { display:none; }' > gds_render.css
-        rsvg-convert gds_render.svg -s gds_render.css -o gds_render_png24.png --no-keep-image-data
+      run: rsvg-convert gds_render.svg -s <(echo 'text{display:none;}') -o gds_render_png24.png --no-keep-image-data
 
     - name: shrink png
-      run: pngquant --nofs --strip --output gds_render.png gds_render_png24.png
+      run: |
+        pngquant --nofs --strip --output gds_render.png gds_render_png24.png
+        ls -al gds_render*.png
 
     - name: populate png cache
       uses: actions/cache@v3

--- a/.github/workflows/wokwi_test.yaml
+++ b/.github/workflows/wokwi_test.yaml
@@ -9,6 +9,8 @@ jobs:
     # need the repo checked out
     - name: checkout repo
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     # install oss fpga tools
     - name: install oss-cad-suite


### PR DESCRIPTION
Inspired by prior work by @psychogenic... lightweight changes to the `gds` GHA so that in GDS to PNG generation:
1. All text labels are removed (they were unreadable and cluttered anyway); and
2. The resulting PNG file is on the order of 50% to 75% smaller.

...and from what I can tell, this actual replacement step is 2~5 times faster, even counting the extra steps and prerequisites.

It does this by:
1. Converting from GDS to SVG (as it did originally, but without the extra Python PNG step)
2. Using `rsvg-convert` instead to get more control over Cairo's SVG to PNG conversion (inc. hiding all text via stylesheet)
3. Using `pngquant` to quantise PNG colours, leading to much better PNG compression.

I tested this in a test branch [here](https://github.com/fooglestuff/tt03p5-submission-template/actions/runs/5168823340) and it shows that the resulting PNG [shrank from 1,846k to 471k](https://github.com/fooglestuff/tt03p5-submission-template/actions/runs/5168823340/jobs/9310747839#step:18:19) (i.e. 75% reduction) while still looking really clear and almost impossible to tell the difference:
![gds_compare](https://github.com/TinyTapeout/tt03p5-submission-template/assets/845120/67b08777-0e4e-4422-b091-4851c62ee2a1)

The overhead is pretty small, installing an extra 6MB of packages.

**NOTE:** In future it would probably be better to integrate this method into the actual [`tt_tool.py`](https://github.com/TinyTapeout/tt-support-tools/blob/tt03/tt_tool.py)'s `--create-png` option, for consistency and convenience.